### PR TITLE
add "toc" option to "glossaries" package: solve link problem for glossaries in table of contents

### DIFF
--- a/tex/commands.tex
+++ b/tex/commands.tex
@@ -93,7 +93,7 @@ colorlinks,linkcolor=blue,citecolor=blue,final]{hyperref}
 \usepackage{makeidx}
 \makeindex
 %%% بسته ایجاد واژه‌نامه با xindy
-\usepackage[xindy,acronym,nonumberlist=true]{glossaries}
+\usepackage[xindy,toc,acronym,nonumberlist=true]{glossaries}
 
 % بسته زیر باگ ناشی از فراخوانی بسته‌های زیاد را برطرف می‌کند.
 \usepackage{morewrites}

--- a/tex/glossaries-settings.tex
+++ b/tex/glossaries-settings.tex
@@ -96,8 +96,6 @@
 	%\cleardoublepage
 	%\phantomsection
 	\baselineskip=.75cm
-	%% با این دستور عنوان فهرست اختصارات به فهرست مطالب اضافه می‌شود. 
-	\addcontentsline{toc}{chapter}{فهرست اختصارات}
 	\setglossarystyle{myAbbrlist}
 	%\begin{LTR}
 		\Oldprintglossary[type=acronym]	
@@ -115,14 +113,10 @@
 	%\phantomsection
 	%% این دستور موجب این می‌شود که واژه‌نامه‌ها در  حالت دو ستونی نوشته شود. 
 	\twocolumn{}
-	%% با این دستور عنوان واژه‌نامه به فهرست مطالب اضافه می‌شود. 
-	\addcontentsline{toc}{chapter}{واژه‌نامهٔ فارسی به انگلیسی}
 	\setglossarystyle{myFaToEn}
 	\Oldprintglossary[type=persian]
 	\clearpage
 	%\phantomsection
-	%% با این دستور عنوان واژه‌نامه به فهرست مطالب اضافه می‌شود. 
-	\addcontentsline{toc}{chapter}{واژه‌نامهٔ انگلیسی به فارسی}
 	\setglossarystyle{myEntoFa}
 	\Oldprintglossary[type=english]	
 	\onecolumn{}


### PR DESCRIPTION
**The problem description**: In current version links to the glossories refere to the previous page for each one.