### PR TITLE
fix latexmkrc's perl system call on windows

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -8,17 +8,17 @@ $bibtex = 'bibtex8 -W -c cp1256fa %O %B';
 
 add_cus_dep('glo', 'gls', 0, 'makeglo2gls');
 sub makeglo2gls {
-    system("xindy -L persian-variant3 -C utf8 -I xindy -M '$_[0]'.xdy -t '$_[0]'.glg -o '$_[0]'.gls '$_[0]'.glo");
+    system("xindy -L persian-variant3 -C utf8 -I xindy -M \"$_[0].xdy\" -t \"$_[0].glg\" -o \"$_[0].gls\" \"$_[0].glo\"");
 }
 
 add_cus_dep('blo', 'bls', 0, 'makeblo2bls');
 sub makeblo2bls {
-    system("xindy -L persian-variant3 -C utf8 -I xindy -M '$_[0]'.xdy -t '$_[0]'.blg -o '$_[0]'.bls '$_[0]'.blo");
+    system("xindy -L persian-variant3 -C utf8 -I xindy -M \"$_[0].xdy\" -t \"$_[0].blg\" -o \"$_[0].bls\" \"$_[0].blo\"");
 }
 
 add_cus_dep('acn', 'acr', 0, 'makeacn2acr');
 sub makeacn2acr {
-    system("xindy -L english -C utf8 -I xindy -M '$_[0]'.xdy -t '$_[0]'.alg -o '$_[0]'.acr '$_[0]'.acn");
+    system("xindy -L english -C utf8 -I xindy -M \"$_[0].xdy\" -t \"$_[0].alg\" -o \"$_[0].acr\" \"$_[0].acn\"");
 }
 
 push @generated_exts, 'glo', 'gls', 'glg', 'glsdefs';


### PR DESCRIPTION
The build chain was failing on Windows:
```
xindy.pl: input file 'main'.glo does not exist at c:\texlive\2021\texmf-dist\scripts\xindy\xindy.pl line 541.
C:\texlive\2021\bin\win32\runscript.tlu:915: command failed with exit code 2:
perl.exe c:\texlive\2021\texmf-dist\scripts\xindy\xindy.pl -L persian-variant3 -C utf8 -I xindy -M 'main'.xdy -t 'main'.glg -o 'main'.gls 'main'.glo
Rule 'cusdep glo gls main', function 'makeglo2gls'
   failed with return code = 512
```
Probably due to the limitation of shell processing on Windows.

The fix is consistent with the examples provided in the documentation of [latexmk](https://ctan.org/pkg/latexmk).

_Moving the apostrophes after the file extensions does not work either._